### PR TITLE
Add support for tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.xml
 *.egg-info
 .#*
 coverage-html
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy, pypy3, flake8
+
+[testenv]
+deps = -rdev-requirements.txt
+commands = nosetests {posargs:-xs --with-coverage --cover-package static --cover-html --cover-html-dir coverage-html tests/}
+
+[testenv:flake8]
+deps =
+    flake8==2.3.0
+    pep8==1.6.2
+commands =
+    flake8 {posargs:static tests --max-complexity=14}


### PR DESCRIPTION
tox helps you test in all supported versions of Python.

It handles all of the virtualenv creation and package installation, so
it could potentially replace the `Makefile`. It is trivial to make
Travis CI leverage it as well.

    $ pip install tox
    ...
    $ tox
    ...
      py26: commands succeeded
      py27: commands succeeded
      py32: commands succeeded
      py33: commands succeeded
      py34: commands succeeded
      pypy: commands succeeded
      pypy3: commands succeeded
    ERROR:   flake8: commands failed