### PR TITLE
Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.xml
 *.egg-info
 .#*
 coverage-html
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+python: 2.7
+sudo: false
+env:
+    - TOX_ENV=py26
+    - TOX_ENV=py27
+    - TOX_ENV=py32
+    - TOX_ENV=py33
+    - TOX_ENV=py34
+    - TOX_ENV=pypy
+    - TOX_ENV=flake8
+
+script: tox -e $TOX_ENV
+
+install:
+    - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy, pypy3, flake8
+
+[testenv]
+deps = -rdev-requirements.txt
+commands = nosetests {posargs:-xs --with-coverage --cover-package static --cover-html --cover-html-dir coverage-html tests/}
+
+[testenv:flake8]
+deps =
+    flake8==2.3.0
+    pep8==1.6.2
+commands =
+    flake8 {posargs:static tests --max-complexity=14}


### PR DESCRIPTION
This depends on the tox support added in #13.

See https://travis-ci.org/msabramo/static/builds/55667607 for an example Travis CI build for my fork. That build is passing, except for `flake8`, which is fixed by #14.